### PR TITLE
Minimal blur effect added to the blocked page overlay

### DIFF
--- a/content_scripts/block.js
+++ b/content_scripts/block.js
@@ -4,7 +4,7 @@
       var overlay = document.createElement('div'), lines = [
         chrome.i18n.getMessage("site_blocked_info"),
         chrome.i18n.getMessage("site_blocked_motivator")
-      ], p, img = document.createElement('img');
+      ], p, underlayEls, img = document.createElement('img');
       overlay.id = 'matchu-pomodoro-extension-overlay';
       overlay.style.position = 'fixed';
       overlay.style.left = 0;
@@ -30,13 +30,12 @@
       }
       document.body.appendChild(overlay);
 
-      try {
-        var elements = document.querySelectorAll('body > *:not(#matchu-pomodoro-extension-overlay)')
-        for (var i = 0; i < elements.length; i++) {
-          elements[i].style.webkitFilter = 'grayscale(0.5) blur(4px)';
+      // Add a minimal blur effect to the blocked page
+      underlayEls = document.querySelectorAll("body > *:not(#matchu-pomodoro-extension-overlay)");
+      for(var i in underlayEls) {
+        if (underlayEls[i].style) {
+          underlayEls[i].style.webkitFilter = "grayscale(0.5) blur(4px)";
         }
-      } catch(e) {
-        // This is okay, the above code just adds a little blur to the blocked page
       }
 
       document.body.style.overflow = "hidden"; // Hide horizontal and vertical scrollbars

--- a/content_scripts/block.js
+++ b/content_scripts/block.js
@@ -12,8 +12,8 @@
       overlay.style.width = '100%';
       overlay.style.height = '100%';
       overlay.style.zIndex = 9000001;
-      overlay.style.backgroundImage = '-webkit-linear-gradient(bottom, #ccc 0%, #fff 75%)';
-      overlay.style.padding = '5em 1em 1em';
+      overlay.style.backgroundImage = '-webkit-linear-gradient(bottom, rgba(210, 210, 210, 0.9) 0%, rgba(255, 255, 255, 0.95) 75%)';
+      overlay.style.padding = '5em 0 1em';
       overlay.style.textAlign = 'center';
       overlay.style.color = '#000';
       overlay.style.font = 'normal normal normal 16px/1 sans-serif';
@@ -29,6 +29,17 @@
         overlay.appendChild(p);
       }
       document.body.appendChild(overlay);
+
+      try {
+        var elements = document.querySelectorAll('body > *:not(#matchu-pomodoro-extension-overlay)')
+        for (var i = 0; i < elements.length; i++) {
+          elements[i].style.webkitFilter = 'grayscale(0.5) blur(4px)';
+        }
+      } catch(e) {
+        // This is okay, the above code just adds a little blur to the blocked page
+      }
+
+      document.body.style.overflow = "hidden"; // Hide horizontal and vertical scrollbars
     }
   }
   

--- a/content_scripts/unblock.js
+++ b/content_scripts/unblock.js
@@ -1,4 +1,14 @@
 (function () {
   var overlay = document.getElementById('matchu-pomodoro-extension-overlay');
   document.body.removeChild(overlay);
+
+  // Remove filters from the blocked page
+  var underlayEls = document.querySelectorAll("body > *");
+  for (var i in underlayEls) {
+    if (underlayEls[i].style) {
+      underlayEls[i].style.webkitFilter = "";
+    }
+  }
+
+  document.body.style.overflow = ""; // Restore horizontal and vertical scrollbars
 })();


### PR DESCRIPTION
This is just an idea. It blurs the blocked webpage content using a -webkit-filter. Screenshot:

![Blurred blocked page](http://dmfranc.com/assets/strict-pomodoro-overlay-effect.png)

Feel free to reject this pull-request :)