### PR TITLE
Prevent resetting the break timer, allow early break termination, and allow auto-starting the work phase

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -78,6 +78,10 @@
     "message": "Clicking on a running break timer starts a new work period",
     "description": "On the options page, label for the checkbox that enables/disables the feature that clicking on a running break timer starts a work period"
   },
+  "options_auto_continue": {
+    "message": "Automatically start a new work period when the break timer finishes",
+    "description": "On the options page, label for the checkbox that enables/disables the feature that the work timer starts automatically at the end of a break"
+  },
   "options_click_restarts_note": {
     "message": "By the strictness philosophy, the only way to <em>cancel</em> a running timer is to disable the extension.",
     "description": "On the options page, note below the label for the click-restarts checkbox explaining that this will not allow users to *cancel* a running timer"

--- a/background.js
+++ b/background.js
@@ -127,6 +127,9 @@ function Pomodoro(options) {
 
   this.onTimerEnd = function (timer) {
     this.running = false;
+    if (PREFS.autoContinue && this.mostRecentMode == 'break') {
+      this.start();
+    }
   }
 
   this.start = function () {
@@ -189,9 +192,9 @@ Pomodoro.Timer = function Timer(pomodoro, options) {
     timer.timeRemaining--;
     options.onTick(timer);
     if(timer.timeRemaining <= 0) {
-      clearInterval(tickInterval);
-      pomodoro.onTimerEnd(timer);
+      timer.stop();
       options.onEnd(timer);
+      pomodoro.onTimerEnd(timer);
     }
   }
 }

--- a/options.html
+++ b/options.html
@@ -146,6 +146,10 @@
         <input id="click-skips" type="checkbox" />
         <label for="click-skips" data-i18n="options_click_skips"></label>
       </div>
+      <div>
+        <input id="auto-continue" type="checkbox" />
+        <label for="auto-continue" data-i18n="options_auto_continue"></label>
+      </div>
       <button type="submit" id="save-button" data-i18n="options_save_changes"></button>
       <span id="save-successful" data-i18n="options_save_successful"></span>
     </form>

--- a/options.js
+++ b/options.js
@@ -27,6 +27,7 @@ var form = document.getElementById('options-form'),
   shouldRingEl = document.getElementById('should-ring'),
   clickRestartsEl = document.getElementById('click-restarts'),
   clickSkipsEl = document.getElementById('click-skips'),
+  autoContinueEl = document.getElementById('auto-continue'),
   saveSuccessfulEl = document.getElementById('save-successful'),
   timeFormatErrorEl = document.getElementById('time-format-error'),
   background = chrome.extension.getBackgroundPage(),
@@ -65,6 +66,7 @@ form.onsubmit = function () {
     shouldRing:         shouldRingEl.checked,
     clickRestarts:      clickRestartsEl.checked,
     clickSkips:         clickSkipsEl.checked,
+    autoContinue:       autoContinueEl.checked,
     whitelist:          whitelistEl.selectedIndex == 1
   })
   saveSuccessfulEl.className = 'show';
@@ -76,6 +78,7 @@ showNotificationsEl.onchange = formAltered;
 shouldRingEl.onchange = formAltered;
 clickRestartsEl.onchange = formAltered;
 clickSkipsEl.onchange = formAltered;
+autoContinueEl.onchange = formAltered;
 whitelistEl.onchange = formAltered;
 
 function formAltered() {
@@ -88,6 +91,7 @@ showNotificationsEl.checked = background.PREFS.showNotifications;
 shouldRingEl.checked = background.PREFS.shouldRing;
 clickRestartsEl.checked = background.PREFS.clickRestarts;
 clickSkipsEl.checked = background.PREFS.clickSkips;
+autoContinueEl.checked = background.PREFS.autoContinue;
 whitelistEl.selectedIndex = background.PREFS.whitelist ? 1 : 0;
 
 var duration, minutes, seconds;


### PR DESCRIPTION
Hi,

I made a few small changes that I thought might be of interest:
1. Under current behavior, clicking a running break timer will reset it to its maximum duration. I changed the semantics of the current option so it only resets work timers (no cheating!), and added a new option that makes clicking on a running break timer end the break early.
2. Under current behavior, when the break timer expires the "blocked" sites remain unblocked until the next work phase is initiated. I added an option to automatically start the work phase as soon as the break timer finishes.

Known issues:
- I only added the option strings in English.
- When autoContinue is set, no notification appears at the end of the break phase. I don't know what the behavior should be, here...maybe this is okay.
