### PR TITLE
Automate Work / Break Cycle

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -70,6 +70,10 @@
     "message": "Ring when a timer finishes (audio)",
     "description": "On the options page, label for the checkbox that enables/disables ringing sound at the end of a timer"
   },
+  "options_auto_mode": {
+    "message": "Alternate between work and break cycles automatically",
+    "description": "On the options page, label for the checkbox that enables/disables automatic flipping between work and break modes"
+  },
   "options_click_restarts": {
     "message": "Clicking on a running timer restarts it",
     "description": "On the options page, label for the checkbox that enables/disables the feature that clicking on a running timer restarts it"

--- a/background.js
+++ b/background.js
@@ -325,7 +325,7 @@ var notification, mainPomodoro = new Pomodoro({
       //        notification appear and disappear in a flash.
       // To Do: International strings      
       if(PREFS.autoMode) {
-         mainPomodoro.start();
+         setTimeout(function(){mainPomodoro.start();}, 30000);
       }
       
     },

--- a/background.js
+++ b/background.js
@@ -320,9 +320,6 @@ var notification, mainPomodoro = new Pomodoro({
       }
       
       // If auto-mode is set, restart the cycle by calling start
-      // Note:  If this is set, users won't see notifications  because we  
-      //        dismissthem on onStart at Line 344. Users may potentially notice
-      //        notification appear and disappear in a flash.
       // To Do: International strings      
       if(PREFS.autoMode) {
          setTimeout(function(){mainPomodoro.start();}, 30000);

--- a/background.js
+++ b/background.js
@@ -318,6 +318,16 @@ var notification, mainPomodoro = new Pomodoro({
         console.log("playing ring", RING);
         RING.play();
       }
+      
+      // If auto-mode is set, restart the cycle by calling start
+      // Note:  If this is set, users won't see notifications  because we  
+      //        dismissthem on onStart at Line 344. Users may potentially notice
+      //        notification appear and disappear in a flash.
+      // To Do: International strings      
+      if(PREFS.autoMode) {
+         mainPomodoro.start();
+      }
+      
     },
     onStart: function (timer) {
       chrome.browserAction.setIcon({

--- a/options.html
+++ b/options.html
@@ -136,6 +136,10 @@
         <label for="should-ring" data-i18n="options_should_ring"></label>
       </div>
       <div>
+        <input id="auto-mode" type="checkbox" />
+        <label for="auto-mode" data-i18n="options_auto_mode"></label>
+      </div>
+      <div>
         <input id="click-restarts" type="checkbox" />
         <label for="click-restarts">
           <span data-i18n="options_click_restarts"></span>

--- a/options.js
+++ b/options.js
@@ -25,6 +25,7 @@ var form = document.getElementById('options-form'),
   whitelistEl = document.getElementById('blacklist-or-whitelist'),
   showNotificationsEl = document.getElementById('show-notifications'),
   shouldRingEl = document.getElementById('should-ring'),
+  autoModeEl =  document.getElementById('auto-mode'),
   clickRestartsEl = document.getElementById('click-restarts'),
   saveSuccessfulEl = document.getElementById('save-successful'),
   timeFormatErrorEl = document.getElementById('time-format-error'),
@@ -62,6 +63,7 @@ form.onsubmit = function () {
     durations:          durations,
     showNotifications:  showNotificationsEl.checked,
     shouldRing:         shouldRingEl.checked,
+    autoMode:           autoModeEl.checked,
     clickRestarts:      clickRestartsEl.checked,
     whitelist:          whitelistEl.selectedIndex == 1
   })
@@ -72,6 +74,7 @@ form.onsubmit = function () {
 siteListEl.onfocus = formAltered;
 showNotificationsEl.onchange = formAltered;
 shouldRingEl.onchange = formAltered;
+autoModeEl.onchange = formAltered;
 clickRestartsEl.onchange = formAltered;
 whitelistEl.onchange = formAltered;
 
@@ -83,6 +86,7 @@ function formAltered() {
 siteListEl.value = background.PREFS.siteList.join("\n");
 showNotificationsEl.checked = background.PREFS.showNotifications;
 shouldRingEl.checked = background.PREFS.shouldRing;
+autoModeEl.checked = background.PREFS.autoMode;
 clickRestartsEl.checked = background.PREFS.clickRestarts;
 whitelistEl.selectedIndex = background.PREFS.whitelist ? 1 : 0;
 


### PR DESCRIPTION
Give the users a choice in preferences section (called 'auto mode')
which makes the extension to go in a work / break loop. This removes the
need to manually intervene to flip the work/break switch.

To Do: International strings. I have updated only locales\EN.

Future Improvements:
1) This option wont work well with Notifications. users won't see
notifications  because we
dismiss them on onStart when the next cycle begins. Users may
potentially notice
notification appear and disappear in a flash. This is minor annoyance or
sometimes un-noticeable. We can potentially uncheck Notifications, When
Auto-Mode is set.

2) I haven't addressed when the work / break loop expires. This will go
on in a loop. The user has to uncheck auto-mode option to break out of
the loop.