### PR TITLE
Add a 10 second timeout on notifications so they are cleared.

### DIFF
--- a/background.js
+++ b/background.js
@@ -305,7 +305,13 @@ var notification, mainPomodoro = new Pomodoro({
           message: chrome.i18n.getMessage("timer_end_notification_body",
                                           nextModeName),
           iconUrl: ICONS.FULL[timer.type]
-        }, function() {});
+        }, function(id) {
+          // Wait 10 seconds and close the notification
+          // so it doesn't build up in the drawer.
+          setTimeout(function(){
+            chrome.notifications.clear(id, function() {});
+          }, 10000);
+        });
       }
       
       if(PREFS.shouldRing) {


### PR DESCRIPTION
Chrome notifications have a little drawer that contains Google Now notifications and any other notifications created (the little bell by the clock on Windows). The Strict-Workflow notifications sit in the drawer if they are not closed while they are on the screen.
