### PR TITLE
Increase the chrome notification priority

### DIFF
--- a/background.js
+++ b/background.js
@@ -304,6 +304,7 @@ var notification, mainPomodoro = new Pomodoro({
           title: chrome.i18n.getMessage("timer_end_notification_header"),
           message: chrome.i18n.getMessage("timer_end_notification_body",
                                           nextModeName),
+          priority: 2,
           iconUrl: ICONS.FULL[timer.type]
         }, function() {});
       }


### PR DESCRIPTION
Increase the chrome notification priority to the highest level (2). Hopefully this will make the pop-up last for longer.
Ref: http://stackoverflow.com/questions/25385140/can-i-control-how-long-chrome-app-notifications-last