### PR TITLE
modified options_ui for firefox compatibility

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,9 @@
    },
    "manifest_version": 2,
    "name": "__MSG_ext_name__",
-   "options_page": "options.html",
+   "options_ui": {
+       "page": "options.html"
+   },
    "permissions": [ "notifications", "tabs", "<all_urls>" ],
    "version": "1.7.0",
    "web_accessible_resources": [


### PR DESCRIPTION
The only change was made to `manifest.json`.
`options_page:` is now `options_ui:page:` to get the options menu to work in firefox.

Tested using chrome version 56.0.2924.87 (64-bit) on ubuntu 16.10
Tested using firefox version 51.0.1 (64-bit) on ubuntu 16.10